### PR TITLE
feat: added exec helpers to sessionSigner

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,51 @@
 [![codecov](https://codecov.io/gh/n2p5/stint/graph/badge.svg)](https://codecov.io/gh/n2p5/stint)
 [![Known Vulnerabilities](https://snyk.io/test/github/n2p5/stint/badge.svg)](https://snyk.io/test/github/n2p5/stint)
 
-Short-lived, non-custodial, zero-balance passkey based session signers for the Cosmos SDK ecosystem.
+**Zero-balance session signers for smooth Web3 UX.** Post, vote, and transact without wallet popups using Passkeys + Cosmos SDK authz + feegrant modules.
 
-> **⚠️ EXPERIMENTAL SOFTWARE WARNING**
+> **⚠️ EXPERIMENTAL SOFTWARE - TESTNET ONLY**
 >
-> **This project is experimental and has NOT undergone a security audit.** Use at your own risk and only with funds you can afford to lose. Do not use in production environments or with significant amounts of cryptocurrency.
+> **This project is experimental and has NOT undergone a security audit.** Only use on testnets with test tokens that have no real value. Do not use with real funds or in production environments.
 
-## Overview
+## What is Stint?
 
-Stint enables ephemeral session signers that can perform limited blockchain actions without requiring constant hardware wallet interaction. It uses Cosmos SDK's `authz` and `feegrant` modules combined with WebAuthn Passkeys for secure, deterministic key derivation.
+Stint creates **temporary signers** that can perform limited actions on behalf of your main wallet without holding any funds. Perfect for social dApps, games, and frequent interactions.
 
-## Features
+**How it works:**
 
-- 🔑 **Passkey-based key derivation** - Uses WebAuthn PRF extension for deterministic, secure key generation
-- 🔐 **Non-custodial** - Session signer's private key never leaves the client
-- ⚡ **Seamless UX** - Sign transactions without hardware wallet popups for authorized actions  
-- 🚀 **Zero balance required** - Session signer works without any token balance
-- 🌐 **Multi-wallet support** - Works with Keplr, Leap, Cosmostation, and any Cosmos wallet
+1. **Create a session signer** using your device's Passkey (fingerprint/Face ID)
+2. **Authorize specific actions** (like posting to social networks) with spending limits
+3. **Interact seamlessly** - no more wallet popups for every small transaction
+
+Your main wallet stays secure, session signers are time-limited, and you can revoke access anytime.
+
+## Why Use Stint?
+
+Perfect for apps that need frequent, small transactions:
+
+### 🌐 **Social Media dApps**
+
+- Post messages without wallet popups
+- Like/react to content instantly
+- Comment and interact seamlessly
+
+### 🎮 **Gaming & NFTs**
+
+- In-game transactions and trades
+- Achievement claims and rewards
+- Tournament entries
+
+### 🗳️ **DAOs & Governance**  
+
+- Vote on multiple proposals
+- Delegate voting power
+- Submit proposals without friction
+
+### 💰 **Micro-payments**
+
+- Content tips and donations
+- Subscription payments
+- Pay-per-use services
 
 ## Installation
 
@@ -36,80 +64,113 @@ yarn add stint-signer
 
 ```typescript
 import { newSessionSigner } from 'stint-signer'
-import { SigningStargateClient } from '@cosmjs/stargate'
 
-// 1. Create session signer
+// 1. Create session signer (triggers Passkey prompt)
 const sessionSigner = await newSessionSigner({
-  primaryClient,  // Your existing SigningStargateClient
-  saltName: 'my-app' // Optional: defaults to 'stint-session'
+  primaryClient  // Your existing SigningStargateClient
 })
 
-// 2. Generate authorization messages
-const authorizedRecipient = 'atone1recipient123...'
+// 2. Define authorized recipient for security
+const authorizedRecipient = 'atone1dither123...' // Only allow sends to this address
+
+// 3. Set up permissions (one-time setup)
 const setupMessages = sessionSigner.generateDelegationMessages({
   sessionExpiration: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
-  spendLimit: { denom: 'uphoton', amount: '1000000' },   // 1 PHOTON spending limit
-  gasLimit: { denom: 'uphoton', amount: '500000' },      // 0.5 PHOTON gas limit
-  allowedRecipients: [authorizedRecipient]               // Restrict to specific recipient
+  spendLimit: { denom: 'uphoton', amount: '1000000' },   // Max 1 PHOTON
+  gasLimit: { denom: 'uphoton', amount: '500000' },      // 0.5 PHOTON for gas
+  allowedRecipients: [authorizedRecipient]              // Restrict to specific address
 })
 
-// 3. Broadcast setup transaction with your primary signer
-const primaryAddress = sessionSigner.primaryAddress()
-await primaryClient.signAndBroadcast(primaryAddress, setupMessages, 'auto')
-
-// 4. Use session signer to send transactions!
-await sessionSigner.client.sendTokens(
-  sessionSigner.primaryAddress(), // Funds come from primary signer
-  authorizedRecipient,           // Must match allowedRecipients
-  [{ denom: 'uphoton', amount: '100000' }], // 0.1 PHOTON
-  'auto',
-  'Sent via session signer'
+await primaryClient.signAndBroadcast(
+  sessionSigner.primaryAddress(), 
+  setupMessages, 
+  'auto'
 )
+
+// 4. Now send transactions instantly! 🚀
+await sessionSigner.execute.send({
+  toAddress: authorizedRecipient,  // Must match allowedRecipients
+  amount: [{ denom: 'uphoton', amount: '100000' }],
+  memo: 'Posted via session signer!'
+})
 ```
 
-## API Reference
+**That's it!** No more wallet popups for authorized transactions.
 
-### `newSessionSigner(config)`
+## Live Example
 
-Creates a new session signer with passkey-based key derivation.
+🎯 **[Try the Dither Demo](./examples/dither-post-demo)** - Post to a decentralized social network without wallet popups!
+
+The demo shows how to:
+
+- Create session signers with WebAuthn Passkeys  
+- Set up permissions in one transaction
+- Post messages instantly using session signers
+
+## Basic API
+
+### Creating a Session Signer
 
 ```typescript
+import { newSessionSigner } from 'stint-signer'
+
 const sessionSigner = await newSessionSigner({
-  primaryClient: SigningStargateClient,  // Required: Your primary address's client
-  saltName?: string,                     // Optional: Salt for key derivation
-  logger?: Logger                        // Optional: Custom logger
+  primaryClient,              // Your SigningStargateClient
+  saltName?: 'my-app',       // Optional: isolate different apps
+  logger?: consoleLogger     // Optional: enable debug logs
 })
 ```
 
-### SessionSigner Methods
+### Setting Up Permissions
 
-- `client`: SigningStargateClient for the session signer
-- `primaryAddress()`: Get the primary signer address
-- `sessionAddress()`: Get the session signer address  
-- `generateDelegationMessages(config)`: Generate setup messages for authorization
-- `generateConditionalDelegationMessages(config)`: Generate messages only for missing grants
-- `hasAuthzGrant(messageType?)`: Check if authz grant exists
-- `hasFeegrant()`: Check if feegrant exists
-- `revokeDelegationMessages(msgTypeUrl?)`: Generate revocation messages
+```typescript
+// Generate permission messages
+const messages = sessionSigner.generateDelegationMessages({
+  sessionExpiration: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
+  spendLimit: { denom: 'uphoton', amount: '1000000' },   // Max spending
+  gasLimit: { denom: 'uphoton', amount: '500000' },      // Gas allowance
+  allowedRecipients: ['atone1...']  // Optional: restrict recipients
+})
 
-## Development
-
-```bash
-pnpm install       # Install dependencies
-pnpm build         # Build library
-pnpm dev           # Run in watch mode
-pnpm test          # Run tests
-pnpm typecheck     # Type check
-pnpm lint          # Lint code
+// Sign with your main wallet (one time)
+await primaryClient.signAndBroadcast(primaryAddress, messages, 'auto')
 ```
 
-## Documentation
+### Using Session Signers
 
-For advanced usage, examples, and detailed documentation, see the [Complete Guide](./docs/GUIDE.md).
+```typescript
+// Send tokens instantly (no wallet popup!)
+await sessionSigner.execute.send({
+  toAddress: 'atone1recipient...',
+  amount: [{ denom: 'uphoton', amount: '100000' }],
+  memo: 'Instant transaction!'
+})
 
-## Examples
+// Check permissions
+const hasPermission = await sessionSigner.hasAuthzGrant()
+const hasGasAllowance = await sessionSigner.hasFeegrant()
+```
 
-- [Dither Post Demo](./examples/dither-post-demo) - Full example of session signer creation with posting on Dither
+## Learn More
+
+📖 **[Complete Guide](./docs/GUIDE.md)** - Advanced usage, security considerations, and detailed examples
+
+🎯 **[Example App](./examples/dither-post-demo)** - Full working demo with Dither social network
+
+## Key Features
+
+✅ **Zero-balance signers** - Session signers never hold funds
+
+✅ **Passkey security** - Uses device biometrics for key derivation
+
+✅ **Time-limited** - Sessions expire automatically
+
+✅ **Revocable** - Cancel permissions anytime
+
+✅ **Scoped permissions** - Limit spending, recipients, and actions
+
+✅ **Multi-wallet support** - Works with Keplr, Leap, Cosmostation
+
 
 ## License
 

--- a/examples/dither-post-demo/README.md
+++ b/examples/dither-post-demo/README.md
@@ -1,11 +1,11 @@
 # Stint Dither Post Demo
 
-A clean, modern demo of Stint session signers built with SvelteKit and DaisyUI.
+A clean, modern demo of Stint session signers built with SvelteKit and DaisyUI. This example shows how to post to [Dither](https://testnet.dither.network), a decentralized social network, without wallet popups on every interaction.
 
 ![Stint Signer Dither Demo](./assets/stint-signer-dither-demo.gif)
 
 > **⚠️ EXPERIMENTAL SOFTWARE - TESTNET ONLY**
-> 
+>
 > This is a demonstration of experimental software that has NOT been security audited. Only use on testnets with test tokens that have no real value. Do not use with real funds or in production environments.
 
 ## Features
@@ -33,10 +33,41 @@ A clean, modern demo of Stint session signers built with SvelteKit and DaisyUI.
 
 ## How to Use
 
-1. **Connect Wallet** - Connect Keplr, Leap, or Cosmostation (primary signer)
-2. **Create Session Signer** - Generate a session signer using WebAuthn Passkey
-3. **Create Authorization** - Set up authz grants and feegrants from primary to session signer
-4. **Send Transaction** - Use the session signer to send transactions on behalf of primary address
+1. **Connect Wallet** - Connect Keplr, Leap, or Cosmostation
+2. **Create Session Signer** - Generate a session signer using your device's biometrics (Passkey)
+3. **Set Up Permissions** - Authorize the session signer to post on your behalf (one-time setup)
+4. **Post Instantly** - Post messages to Dither without wallet popups!
+
+## What's Happening Under the Hood
+
+This demo showcases the power of session signers with a simplified API:
+
+### Key Benefits
+
+- **Zero Balance Required**: Session signer never holds funds
+- **Automatic Gas Payment**: Primary wallet covers all transaction fees via feegrant
+- **Simplified API**: Complex blockchain operations are abstracted away
+- **Seamless UX**: Post to social networks without constant wallet popups
+
+### How Dither Posting Works
+
+Dither posts are small token transfers with your message in the memo field:
+
+```typescript
+// This simple call handles all the complexity:
+await sessionSigner.execute.send({
+  toAddress: DITHER_ADDRESS,
+  amount: [{ denom: 'uphoton', amount: '100' }], // Minimal required amount
+  memo: 'Hello Dither! 🚀' // Your post content
+})
+```
+
+**Behind the scenes:**
+1. Creates a MsgSend transaction
+2. Wraps it in MsgExec for authz delegation
+3. Signs with session signer
+4. Uses feegrant for gas fees
+5. Transfers funds from your primary wallet
 
 ## Project Structure
 
@@ -59,13 +90,14 @@ src/
 └── app.css              # Global styles
 ```
 
-## Technologies Used
+## Tech Stack
 
-- **SvelteKit** - Full-stack web framework
-- **DaisyUI** - Tailwind CSS component library
-- **TypeScript** - Type safety
-- **Stint Signer** - Session signer library
-- **CosmJS** - Cosmos SDK JavaScript library
+- **[SvelteKit](https://kit.svelte.dev)** - Modern web framework
+- **[DaisyUI](https://daisyui.com)** - Beautiful Tailwind CSS components
+- **[TypeScript](https://www.typescriptlang.org)** - Type safety
+- **[Stint](https://github.com/n2p5/stint)** - Session signer library
+- **[CosmJS](https://github.com/cosmos/cosmjs)** - Cosmos SDK client
+- **[AtomOne](https://atomone.zone)** - Cosmos-based blockchain
 
 ## Build for Production
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stint-signer",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Short-lived, non-custodial session signer using passkeys for Cosmos SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/execute.test.ts
+++ b/src/execute.test.ts
@@ -1,0 +1,580 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DeliverTxResponse, StdFee } from '@cosmjs/stargate'
+import { Any } from 'cosmjs-types/google/protobuf/any'
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx'
+import { wrapInMsgExec, createFeeWithGranter, send, custom, createExecuteHelpers } from './execute'
+import { SessionSigner } from './types'
+import { ErrorCodes } from './errors'
+import { Logger } from './logger'
+
+// Mock logger for testing
+const mockLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}
+
+// Mock session signer
+const mockSessionSigner: SessionSigner = {
+  primarySigner: {} as any,
+  sessionSigner: {} as any,
+  client: {
+    signAndBroadcast: vi.fn(),
+  } as any,
+  primaryAddress: () => 'atone1primaryaddr123',
+  sessionAddress: () => 'atone1sessionaddr456',
+  hasAuthzGrant: vi.fn(),
+  hasFeegrant: vi.fn(),
+  generateDelegationMessages: vi.fn(),
+  generateConditionalDelegationMessages: vi.fn(),
+  revokeDelegationMessages: vi.fn(),
+  execute: {} as any,
+}
+
+describe('execute helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('wrapInMsgExec', () => {
+    it('should wrap messages in MsgExec with correct grantee', () => {
+      const granteeAddress = 'atone1grantee123'
+      const mockMessage = Any.fromPartial({
+        typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+        value: new Uint8Array([1, 2, 3]),
+      })
+
+      const result = wrapInMsgExec(granteeAddress, [mockMessage])
+
+      expect(result.typeUrl).toBe('/cosmos.authz.v1beta1.MsgExec')
+      expect(result.value.grantee).toBe(granteeAddress)
+      expect(result.value.msgs).toEqual([mockMessage])
+    })
+
+    it('should handle multiple messages', () => {
+      const granteeAddress = 'atone1grantee123'
+      const message1 = Any.fromPartial({
+        typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+        value: new Uint8Array([1]),
+      })
+      const message2 = Any.fromPartial({
+        typeUrl: '/cosmos.staking.v1beta1.MsgDelegate',
+        value: new Uint8Array([2]),
+      })
+
+      const result = wrapInMsgExec(granteeAddress, [message1, message2])
+
+      expect(result.value.msgs).toHaveLength(2)
+      expect(result.value.msgs).toEqual([message1, message2])
+    })
+
+    it('should handle empty message array', () => {
+      const granteeAddress = 'atone1grantee123'
+
+      const result = wrapInMsgExec(granteeAddress, [])
+
+      expect(result.value.msgs).toEqual([])
+    })
+  })
+
+  describe('createFeeWithGranter', () => {
+    const granterAddress = 'atone1granter123'
+
+    it('should return "auto" when fee is "auto"', () => {
+      const result = createFeeWithGranter(granterAddress, 'auto')
+      expect(result).toBe('auto')
+    })
+
+    it('should use default fee when no fee provided', () => {
+      const result = createFeeWithGranter(granterAddress)
+
+      expect(result).toEqual({
+        amount: [{ denom: 'uphoton', amount: '5000' }],
+        gas: '200000',
+        granter: granterAddress,
+      })
+    })
+
+    it('should merge custom fee with granter', () => {
+      const customFee: StdFee = {
+        amount: [{ denom: 'uatom', amount: '10000' }],
+        gas: '300000',
+      }
+
+      const result = createFeeWithGranter(granterAddress, customFee)
+
+      expect(result).toEqual({
+        amount: [{ denom: 'uatom', amount: '10000' }],
+        gas: '300000',
+        granter: granterAddress,
+      })
+    })
+
+    it('should override granter even if provided in custom fee', () => {
+      const customFee: StdFee = {
+        amount: [{ denom: 'uphoton', amount: '8000' }],
+        gas: '250000',
+        granter: 'atone1wronggranter', // This should be overridden
+      }
+
+      const result = createFeeWithGranter(granterAddress, customFee)
+
+      expect(result).toEqual({
+        amount: [{ denom: 'uphoton', amount: '8000' }],
+        gas: '250000',
+        granter: granterAddress, // Should use provided granter
+      })
+    })
+
+    it('should merge partial fee with defaults', () => {
+      const partialFee: Partial<StdFee> = {
+        gas: '400000',
+      }
+
+      const result = createFeeWithGranter(granterAddress, partialFee as StdFee)
+
+      expect(result).toEqual({
+        amount: [{ denom: 'uphoton', amount: '5000' }], // Default
+        gas: '400000', // Custom
+        granter: granterAddress,
+      })
+    })
+  })
+
+  describe('send', () => {
+    const mockTxResponse: DeliverTxResponse = {
+      code: 0,
+      height: 12345,
+      txIndex: 0,
+      transactionHash: 'ABCD1234',
+      gasUsed: 180000n,
+      gasWanted: 200000n,
+      events: [],
+      msgResponses: [],
+    }
+
+    beforeEach(() => {
+      vi.mocked(mockSessionSigner.client.signAndBroadcast).mockResolvedValue(mockTxResponse)
+    })
+
+    it('should send tokens successfully', async () => {
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+        memo: 'Test transfer',
+      }
+
+      const result = await send(mockSessionSigner, params, mockLogger)
+
+      expect(result).toEqual(mockTxResponse)
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Executing send with session signer',
+        expect.objectContaining({
+          toAddress: params.toAddress,
+          amount: params.amount,
+          memo: params.memo,
+        })
+      )
+      expect(mockSessionSigner.client.signAndBroadcast).toHaveBeenCalledTimes(1)
+    })
+
+    it('should create MsgSend with primary address as sender', async () => {
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+      }
+
+      await send(mockSessionSigner, params, mockLogger)
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Created MsgSend',
+        expect.objectContaining({
+          fromAddress: 'atone1primaryaddr123',
+          toAddress: params.toAddress,
+          amount: params.amount,
+        })
+      )
+    })
+
+    it('should use custom fee when provided', async () => {
+      const customFee: StdFee = {
+        amount: [{ denom: 'uphoton', amount: '8000' }],
+        gas: '300000',
+      }
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+        fee: customFee,
+      }
+
+      await send(mockSessionSigner, params, mockLogger)
+
+      expect(mockSessionSigner.client.signAndBroadcast).toHaveBeenCalledWith(
+        'atone1sessionaddr456',
+        expect.any(Array),
+        expect.objectContaining({
+          amount: [{ denom: 'uphoton', amount: '8000' }],
+          gas: '300000',
+          granter: 'atone1primaryaddr123',
+        }),
+        ''
+      )
+    })
+
+    it('should handle auto fee', async () => {
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+        fee: 'auto' as const,
+      }
+
+      await send(mockSessionSigner, params, mockLogger)
+
+      expect(mockSessionSigner.client.signAndBroadcast).toHaveBeenCalledWith(
+        'atone1sessionaddr456',
+        expect.any(Array),
+        'auto',
+        ''
+      )
+    })
+
+    it('should throw error for invalid recipient address', async () => {
+      const params = {
+        toAddress: '',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+      }
+
+      await expect(send(mockSessionSigner, params, mockLogger)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Invalid recipient address',
+          code: ErrorCodes.INVALID_ADDRESS,
+        })
+      )
+    })
+
+    it('should throw error for invalid amount', async () => {
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [],
+      }
+
+      await expect(send(mockSessionSigner, params, mockLogger)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Invalid amount',
+          code: ErrorCodes.INVALID_AMOUNT,
+        })
+      )
+    })
+
+    it('should handle transaction failure', async () => {
+      const failedTxResponse = {
+        ...mockTxResponse,
+        code: 5,
+        rawLog: 'insufficient funds',
+      }
+      vi.mocked(mockSessionSigner.client.signAndBroadcast).mockResolvedValue(failedTxResponse)
+
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+      }
+
+      await expect(send(mockSessionSigner, params, mockLogger)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Transaction failed: insufficient funds',
+          code: ErrorCodes.INVALID_RESPONSE,
+        })
+      )
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Transaction failed on chain',
+        undefined,
+        expect.objectContaining({
+          code: 5,
+          rawLog: 'insufficient funds',
+        })
+      )
+    })
+
+    it('should handle signAndBroadcast throwing error', async () => {
+      const error = new Error('Network error')
+      vi.mocked(mockSessionSigner.client.signAndBroadcast).mockRejectedValue(error)
+
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+      }
+
+      await expect(send(mockSessionSigner, params, mockLogger)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Failed to execute send transaction',
+          code: ErrorCodes.CLIENT_INITIALIZATION_FAILED,
+        })
+      )
+
+      expect(mockLogger.error).toHaveBeenCalledWith('Failed to execute send', error)
+    })
+
+    it('should truncate long memos in logging', async () => {
+      const longMemo = 'x'.repeat(100)
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+        memo: longMemo,
+      }
+
+      await send(mockSessionSigner, params, mockLogger)
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Executing send with session signer',
+        expect.objectContaining({
+          memo: 'x'.repeat(50) + '...',
+        })
+      )
+    })
+  })
+
+  describe('custom', () => {
+    const mockTxResponse: DeliverTxResponse = {
+      code: 0,
+      height: 12345,
+      txIndex: 0,
+      transactionHash: 'ABCD1234',
+      gasUsed: 180000n,
+      gasWanted: 200000n,
+      events: [],
+      msgResponses: [],
+    }
+
+    beforeEach(() => {
+      vi.mocked(mockSessionSigner.client.signAndBroadcast).mockResolvedValue(mockTxResponse)
+    })
+
+    it('should execute custom messages successfully', async () => {
+      const customMessages = [
+        Any.fromPartial({
+          typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+          value: new Uint8Array([1, 2, 3]),
+        }),
+      ]
+      const params = {
+        messages: customMessages,
+        memo: 'Custom transaction',
+      }
+
+      const result = await custom(mockSessionSigner, params, mockLogger)
+
+      expect(result).toEqual(mockTxResponse)
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Executing custom messages with session signer',
+        expect.objectContaining({
+          messageCount: 1,
+          memo: 'Custom transaction',
+        })
+      )
+    })
+
+    it('should handle multiple custom messages', async () => {
+      const customMessages = [
+        Any.fromPartial({
+          typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+          value: new Uint8Array([1]),
+        }),
+        Any.fromPartial({
+          typeUrl: '/cosmos.staking.v1beta1.MsgDelegate',
+          value: new Uint8Array([2]),
+        }),
+      ]
+      const params = {
+        messages: customMessages,
+      }
+
+      await custom(mockSessionSigner, params, mockLogger)
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Broadcasting custom transaction...',
+        expect.objectContaining({
+          messageCount: 2,
+        })
+      )
+    })
+
+    it('should handle transaction failure', async () => {
+      const failedTxResponse = {
+        ...mockTxResponse,
+        code: 3,
+        rawLog: 'invalid message',
+      }
+      vi.mocked(mockSessionSigner.client.signAndBroadcast).mockResolvedValue(failedTxResponse)
+
+      const params = {
+        messages: [
+          Any.fromPartial({
+            typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+            value: new Uint8Array([1]),
+          }),
+        ],
+      }
+
+      await expect(custom(mockSessionSigner, params, mockLogger)).rejects.toThrow(
+        expect.objectContaining({
+          message: 'Transaction failed: invalid message',
+          code: ErrorCodes.INVALID_RESPONSE,
+        })
+      )
+    })
+
+    it('should use default empty memo when not provided', async () => {
+      const params = {
+        messages: [
+          Any.fromPartial({
+            typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+            value: new Uint8Array([1]),
+          }),
+        ],
+      }
+
+      await custom(mockSessionSigner, params, mockLogger)
+
+      expect(mockSessionSigner.client.signAndBroadcast).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.any(Object),
+        '' // Empty memo
+      )
+    })
+  })
+
+  describe('createExecuteHelpers', () => {
+    it('should create execute helpers that bind sessionSigner and logger', async () => {
+      const helpers = createExecuteHelpers(mockSessionSigner, mockLogger)
+
+      expect(helpers).toHaveProperty('send')
+      expect(helpers).toHaveProperty('custom')
+      expect(typeof helpers.send).toBe('function')
+      expect(typeof helpers.custom).toBe('function')
+    })
+
+    it('should bind send function correctly', async () => {
+      const helpers = createExecuteHelpers(mockSessionSigner, mockLogger)
+      const mockTxResponse: DeliverTxResponse = {
+        code: 0,
+        height: 12345,
+        txIndex: 0,
+        transactionHash: 'ABCD1234',
+        gasUsed: 180000n,
+        gasWanted: 200000n,
+        events: [],
+        msgResponses: [],
+      }
+      vi.mocked(mockSessionSigner.client.signAndBroadcast).mockResolvedValue(mockTxResponse)
+
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+      }
+
+      const result = await helpers.send(params)
+
+      expect(result).toEqual(mockTxResponse)
+      expect(mockSessionSigner.client.signAndBroadcast).toHaveBeenCalled()
+    })
+
+    it('should bind custom function correctly', async () => {
+      const helpers = createExecuteHelpers(mockSessionSigner, mockLogger)
+      const mockTxResponse: DeliverTxResponse = {
+        code: 0,
+        height: 12345,
+        txIndex: 0,
+        transactionHash: 'ABCD1234',
+        gasUsed: 180000n,
+        gasWanted: 200000n,
+        events: [],
+        msgResponses: [],
+      }
+      vi.mocked(mockSessionSigner.client.signAndBroadcast).mockResolvedValue(mockTxResponse)
+
+      const params = {
+        messages: [
+          Any.fromPartial({
+            typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+            value: new Uint8Array([1]),
+          }),
+        ],
+      }
+
+      const result = await helpers.custom(params)
+
+      expect(result).toEqual(mockTxResponse)
+      expect(mockSessionSigner.client.signAndBroadcast).toHaveBeenCalled()
+    })
+  })
+
+  describe('edge cases and error handling', () => {
+    it('should handle MsgSend encoding correctly', async () => {
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+      }
+
+      // Mock the protobuf encoding
+      const mockMsgSend = {
+        fromAddress: 'atone1primaryaddr123',
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+      }
+
+      // Verify that MsgSend.fromPartial would be called with correct parameters
+      const spy = vi.spyOn(MsgSend, 'fromPartial')
+      spy.mockReturnValue(mockMsgSend as any)
+
+      await send(mockSessionSigner, params, mockLogger)
+
+      expect(spy).toHaveBeenCalledWith({
+        fromAddress: 'atone1primaryaddr123',
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+      })
+
+      spy.mockRestore()
+    })
+
+    it('should handle undefined amount gracefully', async () => {
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: undefined as any,
+      }
+
+      await expect(send(mockSessionSigner, params, mockLogger)).rejects.toThrow(
+        expect.objectContaining({
+          code: ErrorCodes.INVALID_AMOUNT,
+        })
+      )
+    })
+
+    it('should handle rawLog fallback when undefined', async () => {
+      const failedTxResponse: DeliverTxResponse = {
+        code: 5,
+        height: 12345,
+        txIndex: 0,
+        transactionHash: 'ABCD1234',
+        gasUsed: 180000n,
+        gasWanted: 200000n,
+        events: [],
+        msgResponses: [],
+        // rawLog is undefined
+      }
+      vi.mocked(mockSessionSigner.client.signAndBroadcast).mockResolvedValue(failedTxResponse)
+
+      const params = {
+        toAddress: 'atone1recipient123',
+        amount: [{ denom: 'uphoton', amount: '1000' }],
+      }
+
+      await expect(send(mockSessionSigner, params, mockLogger)).rejects.toThrow(
+        'Transaction failed: Transaction failed'
+      )
+    })
+  })
+})

--- a/src/execute.ts
+++ b/src/execute.ts
@@ -1,0 +1,242 @@
+import { DeliverTxResponse, StdFee, isDeliverTxSuccess } from '@cosmjs/stargate'
+import { EncodeObject } from '@cosmjs/proto-signing'
+import { Coin } from 'cosmjs-types/cosmos/base/v1beta1/coin'
+import { Any } from 'cosmjs-types/google/protobuf/any'
+import { MsgSend } from 'cosmjs-types/cosmos/bank/v1beta1/tx'
+import { SessionSigner, ExecuteHelpers } from './types'
+import { StintError, ErrorCodes } from './errors'
+import { Logger } from './logger'
+
+/**
+ * Helper to wrap any message in MsgExec for authz delegation
+ */
+export function wrapInMsgExec(granteeAddress: string, messages: Any[]): EncodeObject {
+  const execMsg: EncodeObject = {
+    typeUrl: '/cosmos.authz.v1beta1.MsgExec',
+    value: {
+      grantee: granteeAddress,
+      msgs: messages,
+    },
+  }
+
+  return execMsg
+}
+
+/**
+ * Create fee object with granter for feegrant usage
+ */
+export function createFeeWithGranter(
+  granterAddress: string,
+  fee?: StdFee | 'auto'
+): StdFee | 'auto' {
+  if (fee === 'auto') {
+    return 'auto'
+  }
+
+  const defaultFee: StdFee = {
+    amount: [{ denom: 'uphoton', amount: '5000' }],
+    gas: '200000',
+  }
+
+  const feeWithGranter: StdFee = {
+    ...defaultFee,
+    ...fee,
+    granter: granterAddress,
+  }
+
+  return feeWithGranter
+}
+
+/**
+ * Send tokens using session signer with authz delegation
+ */
+export async function send(
+  sessionSigner: SessionSigner,
+  params: {
+    toAddress: string
+    amount: Coin[]
+    memo?: string
+    fee?: StdFee | 'auto'
+  },
+  logger: Logger
+): Promise<DeliverTxResponse> {
+  const { toAddress, amount, memo = '', fee } = params
+
+  logger.info('Executing send with session signer', {
+    toAddress,
+    amount,
+    memo: memo.slice(0, 50) + (memo.length > 50 ? '...' : ''),
+  })
+
+  // Validate inputs
+  if (!toAddress) {
+    throw new StintError('Invalid recipient address', ErrorCodes.INVALID_ADDRESS, {
+      toAddress,
+    })
+  }
+
+  if (!amount || amount.length === 0) {
+    throw new StintError('Invalid amount', ErrorCodes.INVALID_AMOUNT, { amount })
+  }
+
+  try {
+    // Create MsgSend with primary address as sender
+    const msgSend = MsgSend.fromPartial({
+      fromAddress: sessionSigner.primaryAddress(),
+      toAddress,
+      amount,
+    })
+
+    logger.debug('Created MsgSend', {
+      fromAddress: sessionSigner.primaryAddress(),
+      toAddress,
+      amount,
+    })
+
+    // Encode to bytes
+    const msgSendBytes = MsgSend.encode(msgSend).finish()
+
+    // Wrap in Any type
+    const msgSendAny = Any.fromPartial({
+      typeUrl: '/cosmos.bank.v1beta1.MsgSend',
+      value: msgSendBytes,
+    })
+
+    // Wrap in MsgExec
+    const execMsg = wrapInMsgExec(sessionSigner.sessionAddress(), [msgSendAny])
+
+    // Create fee with granter
+    const feeWithGranter = createFeeWithGranter(sessionSigner.primaryAddress(), fee)
+
+    logger.debug('Broadcasting transaction...', {
+      signer: sessionSigner.sessionAddress(),
+      feeGranter: sessionSigner.primaryAddress(),
+      fee: feeWithGranter,
+    })
+
+    // Sign and broadcast
+    const result = await sessionSigner.client.signAndBroadcast(
+      sessionSigner.sessionAddress(),
+      [execMsg],
+      feeWithGranter,
+      memo
+    )
+
+    if (!isDeliverTxSuccess(result)) {
+      const errorLog = (result as any).rawLog || 'Transaction failed'
+      logger.error('Transaction failed on chain', undefined, {
+        code: result.code,
+        rawLog: errorLog,
+      })
+      throw new StintError(`Transaction failed: ${errorLog}`, ErrorCodes.INVALID_RESPONSE, {
+        code: result.code,
+        rawLog: errorLog,
+      })
+    }
+
+    logger.info('Transaction successful', {
+      transactionHash: result.transactionHash,
+      gasUsed: result.gasUsed,
+      gasWanted: result.gasWanted,
+      height: result.height,
+    })
+
+    return result
+  } catch (error) {
+    if (error instanceof StintError) {
+      throw error
+    }
+
+    logger.error('Failed to execute send', error as Error)
+    throw new StintError(
+      'Failed to execute send transaction',
+      ErrorCodes.CLIENT_INITIALIZATION_FAILED,
+      { error: error instanceof Error ? error.message : String(error) }
+    )
+  }
+}
+
+/**
+ * Execute custom messages with authz delegation
+ */
+export async function custom(
+  sessionSigner: SessionSigner,
+  params: {
+    messages: Any[]
+    memo?: string
+    fee?: StdFee | 'auto'
+  },
+  logger: Logger
+): Promise<DeliverTxResponse> {
+  const { messages, memo = '', fee } = params
+
+  logger.info('Executing custom messages with session signer', {
+    messageCount: messages.length,
+    memo: memo.slice(0, 50) + (memo.length > 50 ? '...' : ''),
+  })
+
+  try {
+    // Wrap all messages in MsgExec
+    const execMsg = wrapInMsgExec(sessionSigner.sessionAddress(), messages)
+
+    // Create fee with granter
+    const feeWithGranter = createFeeWithGranter(sessionSigner.primaryAddress(), fee)
+
+    logger.debug('Broadcasting custom transaction...', {
+      signer: sessionSigner.sessionAddress(),
+      feeGranter: sessionSigner.primaryAddress(),
+      messageCount: messages.length,
+    })
+
+    // Sign and broadcast
+    const result = await sessionSigner.client.signAndBroadcast(
+      sessionSigner.sessionAddress(),
+      [execMsg],
+      feeWithGranter,
+      memo
+    )
+
+    if (!isDeliverTxSuccess(result)) {
+      const errorLog = (result as any).rawLog || 'Transaction failed'
+      logger.error('Transaction failed on chain', undefined, {
+        code: result.code,
+        rawLog: errorLog,
+      })
+      throw new StintError(`Transaction failed: ${errorLog}`, ErrorCodes.INVALID_RESPONSE, {
+        code: result.code,
+        rawLog: errorLog,
+      })
+    }
+
+    logger.info('Custom transaction successful', {
+      transactionHash: result.transactionHash,
+      gasUsed: result.gasUsed,
+      gasWanted: result.gasWanted,
+      height: result.height,
+    })
+
+    return result
+  } catch (error) {
+    if (error instanceof StintError) {
+      throw error
+    }
+
+    logger.error('Failed to execute custom messages', error as Error)
+    throw new StintError(
+      'Failed to execute custom transaction',
+      ErrorCodes.CLIENT_INITIALIZATION_FAILED,
+      { error: error instanceof Error ? error.message : String(error) }
+    )
+  }
+}
+
+/**
+ * Create execute helper methods for a SessionSigner
+ * This abstracts away the complexity of MsgExec wrapping for authz delegation
+ */
+export function createExecuteHelpers(sessionSigner: SessionSigner, logger: Logger): ExecuteHelpers {
+  return {
+    send: (params) => send(sessionSigner, params, logger),
+    custom: (params) => custom(sessionSigner, params, logger),
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,11 @@
 // Main function
 export { newSessionSigner } from './stint'
 
+// Execute helpers (can be used directly for testing/advanced usage)
+export { wrapInMsgExec, createFeeWithGranter, send, custom } from './execute'
+
 // Types
-export type { SessionSigner, SessionSignerConfig, DelegationConfig } from './types'
+export type { SessionSigner, SessionSignerConfig, DelegationConfig, ExecuteHelpers } from './types'
 
 // Error handling
 export { StintError, ErrorCodes } from './errors'

--- a/src/stint.ts
+++ b/src/stint.ts
@@ -17,6 +17,7 @@ import {
 import { getOrCreateDerivedKey } from './passkey'
 import { StintError, ErrorCodes } from './errors'
 import { Logger, noopLogger } from './logger'
+import { createExecuteHelpers } from './execute'
 
 // ============================================================================
 // SESSION SIGNER CREATION
@@ -134,7 +135,13 @@ export async function newSessionSigner(config: SessionSignerConfig): Promise<Ses
       generateConditionalDelegationMessagesFn(signer, config),
     revokeDelegationMessages: (msgTypeUrl?: string) =>
       revokeDelegationMessagesFn(primaryAddress, sessionAddress, msgTypeUrl),
+
+    // Execute helpers - will be added after signer creation
+    execute: null as any,
   }
+
+  // Add execute helpers after signer is created (needs reference to signer)
+  signer.execute = createExecuteHelpers(signer, logger)
 
   return signer
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import { OfflineSigner, DirectSecp256k1Wallet, EncodeObject } from '@cosmjs/proto-signing'
-import { SigningStargateClient, GasPrice } from '@cosmjs/stargate'
+import { SigningStargateClient, GasPrice, DeliverTxResponse, StdFee } from '@cosmjs/stargate'
+import { Coin } from 'cosmjs-types/cosmos/base/v1beta1/coin'
+import { Any } from 'cosmjs-types/google/protobuf/any'
 import { Logger } from './logger'
 
 // Extended interface for SigningStargateClient with internal properties
@@ -79,6 +81,29 @@ export interface FeegrantInfo {
   expiration?: Date
 }
 
+export interface ExecuteHelpers {
+  /**
+   * Send tokens using session signer with authz delegation
+   * Automatically wraps in MsgExec and handles feegrant
+   */
+  send(params: {
+    toAddress: string
+    amount: Coin[]
+    memo?: string
+    fee?: StdFee | 'auto'
+  }): Promise<DeliverTxResponse>
+
+  /**
+   * Execute custom messages with authz delegation
+   * For advanced use cases with pre-encoded Any messages
+   */
+  custom(params: {
+    messages: Any[]
+    memo?: string
+    fee?: StdFee | 'auto'
+  }): Promise<DeliverTxResponse>
+}
+
 export interface SessionSigner {
   primarySigner: OfflineSigner
   sessionSigner: DirectSecp256k1Wallet
@@ -96,4 +121,7 @@ export interface SessionSigner {
   generateDelegationMessages(config: DelegationConfig): EncodeObject[]
   generateConditionalDelegationMessages(config: DelegationConfig): Promise<EncodeObject[]>
   revokeDelegationMessages(msgTypeUrl?: string): EncodeObject[]
+
+  // Execute helpers for simplified authz transactions
+  execute: ExecuteHelpers
 }


### PR DESCRIPTION
With feedback from the Dither team, I'm adding a streamlined flow for the signer to make it easier to execute send and custom message operations. This makes it much easier to use. Added significant updates to documents as well. 