### PR TITLE
feat: add timebound passkey salts with cleaner namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,11 @@ The demo shows how to:
 import { newSessionSigner } from 'stint-signer'
 
 const sessionSigner = await newSessionSigner({
-  primaryClient,              // Your SigningStargateClient
-  saltName?: 'my-app',       // Optional: isolate different apps
-  logger?: consoleLogger     // Optional: enable debug logs
+  primaryClient,                    // Your SigningStargateClient
+  saltName?: 'my-app',             // Optional: isolate different apps
+  stintWindowHours?: 24,           // Optional: key rotation interval (default: 24 hours)
+  usePreviousWindow?: false,       // Optional: use previous time window for grace period
+  logger?: consoleLogger           // Optional: enable debug logs
 })
 ```
 
@@ -157,11 +159,54 @@ const hasGasAllowance = await sessionSigner.hasFeegrant()
 
 🎯 **[Example App](./examples/dither-post-demo)** - Full working demo with Dither social network
 
+## Advanced Configuration
+
+### Window-Based Key Rotation
+
+Stint implements automatic key rotation using time-based windows for enhanced security:
+
+```typescript
+const sessionSigner = await newSessionSigner({
+  primaryClient,
+  saltName: 'my-app',
+  
+  // Key rotates every 8 hours for high-security apps
+  stintWindowHours: 8,
+  
+  // Use previous window during transitions to avoid interruptions
+  usePreviousWindow: false,
+})
+```
+
+**Window Configuration Options:**
+
+- `stintWindowHours: 1` - Hourly rotation (maximum security)
+- `stintWindowHours: 8` - 8-hour rotation (high security)  
+- `stintWindowHours: 24` - Daily rotation (default, balanced)
+- `stintWindowHours: 168` - Weekly rotation (convenience)
+
+**Grace Period Usage:**
+
+When users might be near a window boundary, use `usePreviousWindow: true` to access the previous time window's keys, ensuring uninterrupted access during transitions.
+
+### Debugging Window Boundaries
+
+```typescript
+import { getWindowBoundaries } from 'stint-signer'
+
+const boundaries = getWindowBoundaries(24) // 24-hour windows
+console.log('Current window:', boundaries.windowNumber)
+console.log('Window start:', boundaries.start)
+console.log('Window end:', boundaries.end)
+```
+
 ## Key Features
 
 ✅ **Zero-balance signers** - Session signers never hold funds
 
 ✅ **Passkey security** - Uses device biometrics for key derivation
+
+✅ **Automatic key rotation** - Time-windowed keys rotate automatically
 
 ✅ **Time-limited** - Sessions expire automatically
 

--- a/examples/dither-post-demo/README.md
+++ b/examples/dither-post-demo/README.md
@@ -15,6 +15,7 @@ A clean, modern demo of Stint session signers built with SvelteKit and DaisyUI. 
 - 📱 **Responsive Design** that works on desktop and mobile
 - 🔧 **Type Safety** with full TypeScript support
 - ⚡ **Fast Development** with SvelteKit hot reload
+- 🔐 **Window-Based Key Rotation** for enhanced security with configurable intervals
 
 ## Getting Started
 
@@ -35,6 +36,7 @@ A clean, modern demo of Stint session signers built with SvelteKit and DaisyUI. 
 
 1. **Connect Wallet** - Connect Keplr, Leap, or Cosmostation
 2. **Create Session Signer** - Generate a session signer using your device's biometrics (Passkey)
+   - **Optional**: Configure advanced window-based key rotation settings for enhanced security
 3. **Set Up Permissions** - Authorize the session signer to post on your behalf (one-time setup)
 4. **Post Instantly** - Post messages to Dither without wallet popups!
 
@@ -68,6 +70,23 @@ await sessionSigner.execute.send({
 3. Signs with session signer
 4. Uses feegrant for gas fees
 5. Transfers funds from your primary wallet
+
+### Window-Based Key Rotation
+
+This demo showcases Stint's advanced security feature - automatic key rotation using time-based windows:
+
+- **Configurable Intervals**: Choose from 1 hour (maximum security) to 1 week (convenience)
+- **Automatic Rotation**: Keys rotate deterministically based on UTC time windows
+- **Grace Period**: Option to use previous window keys during transitions
+- **Real-time Display**: See current window number and time until next rotation
+
+The demo includes an advanced configuration panel where you can:
+
+1. **Select rotation interval** (1h, 8h, 24h, 1 week)
+2. **Enable grace period** with "Use Previous Window" option
+3. **View current window status** including time remaining
+
+This provides an additional security layer - even if a session key is compromised, it's only valid for the current time window.
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stint-signer",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Short-lived, non-custodial session signer using passkeys for Cosmos SDK",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ export { newSessionSigner } from './stint'
 // Execute helpers (can be used directly for testing/advanced usage)
 export { wrapInMsgExec, createFeeWithGranter, send, custom } from './execute'
 
+// Window utilities (for debugging and validation)
+export { getWindowBoundaries } from './passkey'
+
 // Types
 export type { SessionSigner, SessionSignerConfig, DelegationConfig, ExecuteHelpers } from './types'
 

--- a/src/passkey.test.ts
+++ b/src/passkey.test.ts
@@ -935,32 +935,32 @@ describe('passkey utilities', () => {
       windowTestCases.forEach(({ name, windowHours, description }) => {
         it(`should handle ${name}`, () => {
           const boundaries = getWindowBoundaries(windowHours)
-          
+
           // Verify structure
           expect(boundaries).toHaveProperty('start')
           expect(boundaries).toHaveProperty('end')
           expect(boundaries).toHaveProperty('windowNumber')
-          
+
           // Verify types
           expect(boundaries.start).toBeInstanceOf(Date)
           expect(boundaries.end).toBeInstanceOf(Date)
           expect(typeof boundaries.windowNumber).toBe('number')
-          
+
           // Verify window duration
           const durationMs = boundaries.end.getTime() - boundaries.start.getTime()
           const expectedDurationMs = windowHours * 60 * 60 * 1000
           expect(durationMs).toBe(expectedDurationMs)
-          
+
           // Verify current time is within window
           const now = Date.now()
           expect(now).toBeGreaterThanOrEqual(boundaries.start.getTime())
           expect(now).toBeLessThan(boundaries.end.getTime())
-          
+
           // Verify window number calculation
           const windowMs = windowHours * 60 * 60 * 1000
           const expectedWindowNumber = Math.floor(now / windowMs)
           expect(boundaries.windowNumber).toBe(expectedWindowNumber)
-          
+
           // Log description for documentation
           expect(description).toBeDefined()
         })
@@ -968,7 +968,7 @@ describe('passkey utilities', () => {
 
       it('should handle default 24-hour window when no parameter provided', () => {
         const boundaries = getWindowBoundaries()
-        
+
         const durationMs = boundaries.end.getTime() - boundaries.start.getTime()
         const expectedDurationMs = 24 * 60 * 60 * 1000 // 24 hours in ms
         expect(durationMs).toBe(expectedDurationMs)
@@ -977,7 +977,7 @@ describe('passkey utilities', () => {
       it('should produce consistent results for same window hour values', () => {
         const boundaries1 = getWindowBoundaries(24)
         const boundaries2 = getWindowBoundaries(24)
-        
+
         // Should be the same window (called within same millisecond usually)
         expect(boundaries1.windowNumber).toBe(boundaries2.windowNumber)
         expect(boundaries1.start.getTime()).toBe(boundaries2.start.getTime())
@@ -988,7 +988,7 @@ describe('passkey utilities', () => {
         // Test very small window
         const small = getWindowBoundaries(0.1) // 6 minutes
         expect(small.end.getTime() - small.start.getTime()).toBe(0.1 * 60 * 60 * 1000)
-        
+
         // Test very large window
         const large = getWindowBoundaries(8760) // 1 year
         expect(large.end.getTime() - large.start.getTime()).toBe(8760 * 60 * 60 * 1000)
@@ -1059,29 +1059,31 @@ describe('passkey utilities', () => {
         },
       ]
 
-      windowCalculationTestCases.forEach(({ name, timestamp, windowHours, expectedWindowNumber }) => {
-        it(`should calculate correct window number ${name}`, () => {
-          // Mock Date.now to return our test timestamp
-          Date.now = vi.fn().mockReturnValue(timestamp)
-          
-          const boundaries = getWindowBoundaries(windowHours)
-          
-          expect(boundaries.windowNumber).toBe(expectedWindowNumber)
-          
-          // Verify the window start aligns with our calculation
-          const windowMs = windowHours * 60 * 60 * 1000
-          const expectedStart = expectedWindowNumber * windowMs
-          expect(boundaries.start.getTime()).toBe(expectedStart)
-          
-          // Verify the window end is exactly one window duration later
-          const expectedEnd = expectedStart + windowMs
-          expect(boundaries.end.getTime()).toBe(expectedEnd)
-          
-          // Verify our mocked timestamp falls within the window
-          expect(timestamp).toBeGreaterThanOrEqual(boundaries.start.getTime())
-          expect(timestamp).toBeLessThan(boundaries.end.getTime())
-        })
-      })
+      windowCalculationTestCases.forEach(
+        ({ name, timestamp, windowHours, expectedWindowNumber }) => {
+          it(`should calculate correct window number ${name}`, () => {
+            // Mock Date.now to return our test timestamp
+            Date.now = vi.fn().mockReturnValue(timestamp)
+
+            const boundaries = getWindowBoundaries(windowHours)
+
+            expect(boundaries.windowNumber).toBe(expectedWindowNumber)
+
+            // Verify the window start aligns with our calculation
+            const windowMs = windowHours * 60 * 60 * 1000
+            const expectedStart = expectedWindowNumber * windowMs
+            expect(boundaries.start.getTime()).toBe(expectedStart)
+
+            // Verify the window end is exactly one window duration later
+            const expectedEnd = expectedStart + windowMs
+            expect(boundaries.end.getTime()).toBe(expectedEnd)
+
+            // Verify our mocked timestamp falls within the window
+            expect(timestamp).toBeGreaterThanOrEqual(boundaries.start.getTime())
+            expect(timestamp).toBeLessThan(boundaries.end.getTime())
+          })
+        }
+      )
     })
 
     describe('window boundary transitions', () => {
@@ -1098,22 +1100,22 @@ describe('passkey utilities', () => {
       it('should handle transition from one window to next', () => {
         const windowHours = 24
         const windowMs = windowHours * 60 * 60 * 1000
-        
+
         // Test just before boundary
         Date.now = vi.fn().mockReturnValue(windowMs - 1)
         const beforeBoundary = getWindowBoundaries(windowHours)
         expect(beforeBoundary.windowNumber).toBe(0)
-        
+
         // Test exactly at boundary
         Date.now = vi.fn().mockReturnValue(windowMs)
         const atBoundary = getWindowBoundaries(windowHours)
         expect(atBoundary.windowNumber).toBe(1)
-        
+
         // Test just after boundary
         Date.now = vi.fn().mockReturnValue(windowMs + 1)
         const afterBoundary = getWindowBoundaries(windowHours)
         expect(afterBoundary.windowNumber).toBe(1)
-        
+
         // Verify windows are consecutive
         expect(atBoundary.windowNumber).toBe(beforeBoundary.windowNumber + 1)
         expect(afterBoundary.windowNumber).toBe(beforeBoundary.windowNumber + 1)
@@ -1123,14 +1125,14 @@ describe('passkey utilities', () => {
         const windowHours = 8
         const windowMs = windowHours * 60 * 60 * 1000
         const boundaryTime = windowMs * 5 // 5th window boundary
-        
+
         // Multiple calls at exact same timestamp should be identical
         Date.now = vi.fn().mockReturnValue(boundaryTime)
-        
+
         const call1 = getWindowBoundaries(windowHours)
         const call2 = getWindowBoundaries(windowHours)
         const call3 = getWindowBoundaries(windowHours)
-        
+
         expect(call1.windowNumber).toBe(call2.windowNumber)
         expect(call2.windowNumber).toBe(call3.windowNumber)
         expect(call1.start.getTime()).toBe(call2.start.getTime())
@@ -1140,7 +1142,7 @@ describe('passkey utilities', () => {
       it('should handle microsecond precision at boundaries', () => {
         const windowHours = 1 // 1 hour window for more precise testing
         const windowMs = windowHours * 60 * 60 * 1000
-        
+
         // Test timestamps very close to boundary
         const testPoints = [
           windowMs - 0.1,
@@ -1149,11 +1151,11 @@ describe('passkey utilities', () => {
           windowMs + 0.01,
           windowMs + 0.1,
         ]
-        
+
         testPoints.forEach((timestamp) => {
           Date.now = vi.fn().mockReturnValue(timestamp)
           const boundaries = getWindowBoundaries(windowHours)
-          
+
           if (timestamp < windowMs) {
             expect(boundaries.windowNumber).toBe(0)
           } else {
@@ -1177,15 +1179,15 @@ describe('passkey utilities', () => {
 
       it('should generate different salt for different window numbers', async () => {
         const mockWebAuthn = setupWebAuthnMock({ prfSupported: true })
-        
+
         // Track the salts used in PRF calls
         const capturedSalts: string[] = []
-        
+
         mockWebAuthn.mockGet.mockImplementation(async (options: any) => {
           const saltFirst = new TextDecoder().decode(options.publicKey.extensions.prf.eval.first)
           const saltSecond = new TextDecoder().decode(options.publicKey.extensions.prf.eval.second)
           capturedSalts.push(saltFirst, saltSecond)
-          
+
           return {
             id: 'mock-credential-id',
             rawId: new ArrayBuffer(0),
@@ -1216,15 +1218,15 @@ describe('passkey utilities', () => {
         // Verify salt format includes the explicit window number
         expect(capturedSalts.length).toBeGreaterThan(0)
         const saltUsed = capturedSalts[0]
-        
+
         // Remove the PRF suffix (\x00) that gets appended for the first PRF call
         const nullChar = String.fromCharCode(0)
         const baseSalt = saltUsed.endsWith(nullChar) ? saltUsed.slice(0, -1) : saltUsed
-        
+
         // Parse the salt components: domain:address:purpose:windowNumber
         const parts = baseSalt.split(':')
         expect(parts).toHaveLength(4)
-        
+
         const [domain, address, purpose, windowNumber] = parts
         // Domain could be test.example.com or localhost depending on test environment
         expect(['test.example.com', 'localhost']).toContain(domain)
@@ -1235,12 +1237,12 @@ describe('passkey utilities', () => {
 
       it('should generate time-based salt when no explicit window number provided', async () => {
         const mockWebAuthn = setupWebAuthnMock({ prfSupported: true })
-        
+
         let capturedSalt: string = ''
-        
+
         mockWebAuthn.mockGet.mockImplementation(async (options: any) => {
           capturedSalt = new TextDecoder().decode(options.publicKey.extensions.prf.eval.first)
-          
+
           return {
             id: 'mock-credential-id',
             rawId: new ArrayBuffer(0),
@@ -1270,16 +1272,16 @@ describe('passkey utilities', () => {
         // Remove the PRF suffix (\x00) that gets appended for the first PRF call
         const nullChar = String.fromCharCode(0)
         const baseSalt = capturedSalt.endsWith(nullChar) ? capturedSalt.slice(0, -1) : capturedSalt
-        
+
         const parts = baseSalt.split(':')
         expect(parts).toHaveLength(4) // domain:address:purpose:windowNumber
-        
+
         const [domain, address, purpose, windowNumber] = parts
         // Domain could be test.example.com or localhost depending on test environment
         expect(['test.example.com', 'localhost']).toContain(domain)
         expect(address).toBe('atone1test123')
         expect(purpose).toBe('test-salt')
-        
+
         // Should contain a calculated window number (numeric value)
         const parsedWindowNumber = parseInt(windowNumber)
         expect(parsedWindowNumber).toBeGreaterThanOrEqual(0)
@@ -1288,13 +1290,13 @@ describe('passkey utilities', () => {
 
       it('should generate different salts for different window sizes', async () => {
         const mockWebAuthn = setupWebAuthnMock({ prfSupported: true })
-        
+
         const capturedSalts: string[] = []
-        
+
         mockWebAuthn.mockGet.mockImplementation(async (options: any) => {
           const salt = new TextDecoder().decode(options.publicKey.extensions.prf.eval.first)
           capturedSalts.push(salt)
-          
+
           return {
             id: 'mock-credential-id',
             rawId: new ArrayBuffer(0),
@@ -1317,7 +1319,7 @@ describe('passkey utilities', () => {
         const timestamp = Date.now()
         const originalDateNow = Date.now
         Date.now = vi.fn().mockReturnValue(timestamp)
-        
+
         try {
           // 24 hour window
           await getOrCreateDerivedKey({
@@ -1326,7 +1328,7 @@ describe('passkey utilities', () => {
             stintWindowHours: 24,
           })
 
-          // 8 hour window  
+          // 8 hour window
           await getOrCreateDerivedKey({
             address: 'atone1test123',
             saltName: 'test-salt',
@@ -1336,12 +1338,11 @@ describe('passkey utilities', () => {
           // Should have different window numbers due to different window sizes
           expect(capturedSalts).toHaveLength(2)
           expect(capturedSalts[0]).not.toBe(capturedSalts[1])
-          
+
           // Extract window numbers
           const windowNumber24h = parseInt(capturedSalts[0].split(':')[3])
           const windowNumber8h = parseInt(capturedSalts[1].split(':')[3])
           expect(windowNumber24h).not.toBe(windowNumber8h)
-          
         } finally {
           Date.now = originalDateNow
         }

--- a/src/passkey.test.ts
+++ b/src/passkey.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { sha256 } from '@cosmjs/crypto'
 import { toHex } from '@cosmjs/encoding'
-import { getOrCreateDerivedKey } from './passkey'
+import { getOrCreateDerivedKey, getWindowBoundaries } from './passkey'
 import { setupWebAuthnMock, cleanupWebAuthnMock } from './test-utils/webauthn-mock'
 
 describe('passkey utilities', () => {
@@ -893,6 +893,459 @@ describe('passkey utilities', () => {
       expect(result.credentialId).toBe('mock-credential-id')
       expect(result.privateKey).toMatch(/^[0-9a-f]{64}$/)
       expect(mockLogger.debug).toHaveBeenCalled()
+    })
+  })
+
+  describe('window-based time calculations', () => {
+    describe('getWindowBoundaries', () => {
+      // Table-driven tests for various window sizes
+      const windowTestCases = [
+        {
+          name: '24 hour window (default)',
+          windowHours: 24,
+          description: 'Standard daily window',
+        },
+        {
+          name: '8 hour window',
+          windowHours: 8,
+          description: 'Shorter interval for higher security',
+        },
+        {
+          name: '39 hour window (odd number)',
+          windowHours: 39,
+          description: 'Non-standard interval for special use cases',
+        },
+        {
+          name: '48 hour window',
+          windowHours: 48,
+          description: 'Extended weekend-friendly interval',
+        },
+        {
+          name: '1 hour window',
+          windowHours: 1,
+          description: 'Hourly rotation for maximum security',
+        },
+        {
+          name: '168 hour window (1 week)',
+          windowHours: 168,
+          description: 'Weekly rotation for convenience',
+        },
+      ]
+
+      windowTestCases.forEach(({ name, windowHours, description }) => {
+        it(`should handle ${name}`, () => {
+          const boundaries = getWindowBoundaries(windowHours)
+          
+          // Verify structure
+          expect(boundaries).toHaveProperty('start')
+          expect(boundaries).toHaveProperty('end')
+          expect(boundaries).toHaveProperty('windowNumber')
+          
+          // Verify types
+          expect(boundaries.start).toBeInstanceOf(Date)
+          expect(boundaries.end).toBeInstanceOf(Date)
+          expect(typeof boundaries.windowNumber).toBe('number')
+          
+          // Verify window duration
+          const durationMs = boundaries.end.getTime() - boundaries.start.getTime()
+          const expectedDurationMs = windowHours * 60 * 60 * 1000
+          expect(durationMs).toBe(expectedDurationMs)
+          
+          // Verify current time is within window
+          const now = Date.now()
+          expect(now).toBeGreaterThanOrEqual(boundaries.start.getTime())
+          expect(now).toBeLessThan(boundaries.end.getTime())
+          
+          // Verify window number calculation
+          const windowMs = windowHours * 60 * 60 * 1000
+          const expectedWindowNumber = Math.floor(now / windowMs)
+          expect(boundaries.windowNumber).toBe(expectedWindowNumber)
+          
+          // Log description for documentation
+          expect(description).toBeDefined()
+        })
+      })
+
+      it('should handle default 24-hour window when no parameter provided', () => {
+        const boundaries = getWindowBoundaries()
+        
+        const durationMs = boundaries.end.getTime() - boundaries.start.getTime()
+        const expectedDurationMs = 24 * 60 * 60 * 1000 // 24 hours in ms
+        expect(durationMs).toBe(expectedDurationMs)
+      })
+
+      it('should produce consistent results for same window hour values', () => {
+        const boundaries1 = getWindowBoundaries(24)
+        const boundaries2 = getWindowBoundaries(24)
+        
+        // Should be the same window (called within same millisecond usually)
+        expect(boundaries1.windowNumber).toBe(boundaries2.windowNumber)
+        expect(boundaries1.start.getTime()).toBe(boundaries2.start.getTime())
+        expect(boundaries1.end.getTime()).toBe(boundaries2.end.getTime())
+      })
+
+      it('should handle edge case window sizes', () => {
+        // Test very small window
+        const small = getWindowBoundaries(0.1) // 6 minutes
+        expect(small.end.getTime() - small.start.getTime()).toBe(0.1 * 60 * 60 * 1000)
+        
+        // Test very large window
+        const large = getWindowBoundaries(8760) // 1 year
+        expect(large.end.getTime() - large.start.getTime()).toBe(8760 * 60 * 60 * 1000)
+      })
+    })
+
+    describe('window number calculations with specific times', () => {
+      // Mock Date.now to test specific scenarios
+      let originalDateNow: typeof Date.now
+
+      beforeEach(() => {
+        originalDateNow = Date.now
+      })
+
+      afterEach(() => {
+        Date.now = originalDateNow
+      })
+
+      // Table-driven tests for window calculations
+      const windowCalculationTestCases = [
+        {
+          name: 'at epoch start',
+          timestamp: 0, // Unix epoch start
+          windowHours: 24,
+          expectedWindowNumber: 0,
+        },
+        {
+          name: 'exactly at 24 hour boundary',
+          timestamp: 24 * 60 * 60 * 1000, // Exactly 24 hours after epoch
+          windowHours: 24,
+          expectedWindowNumber: 1,
+        },
+        {
+          name: 'in middle of first 24 hour window',
+          timestamp: 12 * 60 * 60 * 1000, // 12 hours after epoch
+          windowHours: 24,
+          expectedWindowNumber: 0,
+        },
+        {
+          name: 'at 8 hour boundary',
+          timestamp: 8 * 60 * 60 * 1000, // 8 hours after epoch
+          windowHours: 8,
+          expectedWindowNumber: 1,
+        },
+        {
+          name: 'in 39 hour window (odd number)',
+          timestamp: 78 * 60 * 60 * 1000, // 78 hours = 2 * 39 hours
+          windowHours: 39,
+          expectedWindowNumber: 2,
+        },
+        {
+          name: 'just before boundary',
+          timestamp: 24 * 60 * 60 * 1000 - 1, // 1ms before 24 hour boundary
+          windowHours: 24,
+          expectedWindowNumber: 0,
+        },
+        {
+          name: 'far future timestamp',
+          timestamp: 365 * 24 * 60 * 60 * 1000, // 1 year
+          windowHours: 24,
+          expectedWindowNumber: 365,
+        },
+        {
+          name: 'with 48 hour window',
+          timestamp: 96 * 60 * 60 * 1000, // 96 hours = 2 * 48 hours
+          windowHours: 48,
+          expectedWindowNumber: 2,
+        },
+      ]
+
+      windowCalculationTestCases.forEach(({ name, timestamp, windowHours, expectedWindowNumber }) => {
+        it(`should calculate correct window number ${name}`, () => {
+          // Mock Date.now to return our test timestamp
+          Date.now = vi.fn().mockReturnValue(timestamp)
+          
+          const boundaries = getWindowBoundaries(windowHours)
+          
+          expect(boundaries.windowNumber).toBe(expectedWindowNumber)
+          
+          // Verify the window start aligns with our calculation
+          const windowMs = windowHours * 60 * 60 * 1000
+          const expectedStart = expectedWindowNumber * windowMs
+          expect(boundaries.start.getTime()).toBe(expectedStart)
+          
+          // Verify the window end is exactly one window duration later
+          const expectedEnd = expectedStart + windowMs
+          expect(boundaries.end.getTime()).toBe(expectedEnd)
+          
+          // Verify our mocked timestamp falls within the window
+          expect(timestamp).toBeGreaterThanOrEqual(boundaries.start.getTime())
+          expect(timestamp).toBeLessThan(boundaries.end.getTime())
+        })
+      })
+    })
+
+    describe('window boundary transitions', () => {
+      let originalDateNow: typeof Date.now
+
+      beforeEach(() => {
+        originalDateNow = Date.now
+      })
+
+      afterEach(() => {
+        Date.now = originalDateNow
+      })
+
+      it('should handle transition from one window to next', () => {
+        const windowHours = 24
+        const windowMs = windowHours * 60 * 60 * 1000
+        
+        // Test just before boundary
+        Date.now = vi.fn().mockReturnValue(windowMs - 1)
+        const beforeBoundary = getWindowBoundaries(windowHours)
+        expect(beforeBoundary.windowNumber).toBe(0)
+        
+        // Test exactly at boundary
+        Date.now = vi.fn().mockReturnValue(windowMs)
+        const atBoundary = getWindowBoundaries(windowHours)
+        expect(atBoundary.windowNumber).toBe(1)
+        
+        // Test just after boundary
+        Date.now = vi.fn().mockReturnValue(windowMs + 1)
+        const afterBoundary = getWindowBoundaries(windowHours)
+        expect(afterBoundary.windowNumber).toBe(1)
+        
+        // Verify windows are consecutive
+        expect(atBoundary.windowNumber).toBe(beforeBoundary.windowNumber + 1)
+        expect(afterBoundary.windowNumber).toBe(beforeBoundary.windowNumber + 1)
+      })
+
+      it('should handle rapid successive calls at boundary', () => {
+        const windowHours = 8
+        const windowMs = windowHours * 60 * 60 * 1000
+        const boundaryTime = windowMs * 5 // 5th window boundary
+        
+        // Multiple calls at exact same timestamp should be identical
+        Date.now = vi.fn().mockReturnValue(boundaryTime)
+        
+        const call1 = getWindowBoundaries(windowHours)
+        const call2 = getWindowBoundaries(windowHours)
+        const call3 = getWindowBoundaries(windowHours)
+        
+        expect(call1.windowNumber).toBe(call2.windowNumber)
+        expect(call2.windowNumber).toBe(call3.windowNumber)
+        expect(call1.start.getTime()).toBe(call2.start.getTime())
+        expect(call2.start.getTime()).toBe(call3.start.getTime())
+      })
+
+      it('should handle microsecond precision at boundaries', () => {
+        const windowHours = 1 // 1 hour window for more precise testing
+        const windowMs = windowHours * 60 * 60 * 1000
+        
+        // Test timestamps very close to boundary
+        const testPoints = [
+          windowMs - 0.1,
+          windowMs - 0.01,
+          windowMs,
+          windowMs + 0.01,
+          windowMs + 0.1,
+        ]
+        
+        testPoints.forEach((timestamp) => {
+          Date.now = vi.fn().mockReturnValue(timestamp)
+          const boundaries = getWindowBoundaries(windowHours)
+          
+          if (timestamp < windowMs) {
+            expect(boundaries.windowNumber).toBe(0)
+          } else {
+            expect(boundaries.windowNumber).toBe(1)
+          }
+        })
+      })
+    })
+
+    describe('generateStintSalt integration with window numbers', () => {
+      beforeEach(() => {
+        Object.defineProperty(window, 'location', {
+          value: { hostname: 'test.example.com' },
+          writable: true,
+        })
+      })
+
+      afterEach(() => {
+        cleanupWebAuthnMock()
+      })
+
+      it('should generate different salt for different window numbers', async () => {
+        const mockWebAuthn = setupWebAuthnMock({ prfSupported: true })
+        
+        // Track the salts used in PRF calls
+        const capturedSalts: string[] = []
+        
+        mockWebAuthn.mockGet.mockImplementation(async (options: any) => {
+          const saltFirst = new TextDecoder().decode(options.publicKey.extensions.prf.eval.first)
+          const saltSecond = new TextDecoder().decode(options.publicKey.extensions.prf.eval.second)
+          capturedSalts.push(saltFirst, saltSecond)
+          
+          return {
+            id: 'mock-credential-id',
+            rawId: new ArrayBuffer(0),
+            response: {
+              userHandle: new TextEncoder().encode('atone1test123').buffer,
+            } as any,
+            type: 'public-key' as const,
+            authenticatorAttachment: null,
+            getClientExtensionResults: () => ({
+              prf: {
+                results: {
+                  first: new Uint8Array(32).fill(123),
+                  second: new Uint8Array(32).fill(124),
+                },
+              },
+            }),
+          } as any
+        })
+
+        // Test with explicit window number
+        await getOrCreateDerivedKey({
+          address: 'atone1test123',
+          saltName: 'test-salt',
+          stintWindowHours: 24,
+          windowNumber: 42, // Explicit window number
+        })
+
+        // Verify salt format includes the explicit window number
+        expect(capturedSalts.length).toBeGreaterThan(0)
+        const saltUsed = capturedSalts[0]
+        
+        // Remove the PRF suffix (\x00) that gets appended for the first PRF call
+        const nullChar = String.fromCharCode(0)
+        const baseSalt = saltUsed.endsWith(nullChar) ? saltUsed.slice(0, -1) : saltUsed
+        
+        // Parse the salt components: domain:address:purpose:windowNumber
+        const parts = baseSalt.split(':')
+        expect(parts).toHaveLength(4)
+        
+        const [domain, address, purpose, windowNumber] = parts
+        // Domain could be test.example.com or localhost depending on test environment
+        expect(['test.example.com', 'localhost']).toContain(domain)
+        expect(address).toBe('atone1test123')
+        expect(purpose).toBe('test-salt')
+        expect(windowNumber).toBe('42') // Should contain our explicit window number
+      })
+
+      it('should generate time-based salt when no explicit window number provided', async () => {
+        const mockWebAuthn = setupWebAuthnMock({ prfSupported: true })
+        
+        let capturedSalt: string = ''
+        
+        mockWebAuthn.mockGet.mockImplementation(async (options: any) => {
+          capturedSalt = new TextDecoder().decode(options.publicKey.extensions.prf.eval.first)
+          
+          return {
+            id: 'mock-credential-id',
+            rawId: new ArrayBuffer(0),
+            response: {
+              userHandle: new TextEncoder().encode('atone1test123').buffer,
+            } as any,
+            type: 'public-key' as const,
+            authenticatorAttachment: null,
+            getClientExtensionResults: () => ({
+              prf: {
+                results: {
+                  first: new Uint8Array(32).fill(123),
+                },
+              },
+            }),
+          } as any
+        })
+
+        // Test without explicit window number (should use current time)
+        await getOrCreateDerivedKey({
+          address: 'atone1test123',
+          saltName: 'test-salt',
+          stintWindowHours: 24,
+        })
+
+        // Verify salt format
+        // Remove the PRF suffix (\x00) that gets appended for the first PRF call
+        const nullChar = String.fromCharCode(0)
+        const baseSalt = capturedSalt.endsWith(nullChar) ? capturedSalt.slice(0, -1) : capturedSalt
+        
+        const parts = baseSalt.split(':')
+        expect(parts).toHaveLength(4) // domain:address:purpose:windowNumber
+        
+        const [domain, address, purpose, windowNumber] = parts
+        // Domain could be test.example.com or localhost depending on test environment
+        expect(['test.example.com', 'localhost']).toContain(domain)
+        expect(address).toBe('atone1test123')
+        expect(purpose).toBe('test-salt')
+        
+        // Should contain a calculated window number (numeric value)
+        const parsedWindowNumber = parseInt(windowNumber)
+        expect(parsedWindowNumber).toBeGreaterThanOrEqual(0)
+        expect(Number.isInteger(parsedWindowNumber)).toBe(true)
+      })
+
+      it('should generate different salts for different window sizes', async () => {
+        const mockWebAuthn = setupWebAuthnMock({ prfSupported: true })
+        
+        const capturedSalts: string[] = []
+        
+        mockWebAuthn.mockGet.mockImplementation(async (options: any) => {
+          const salt = new TextDecoder().decode(options.publicKey.extensions.prf.eval.first)
+          capturedSalts.push(salt)
+          
+          return {
+            id: 'mock-credential-id',
+            rawId: new ArrayBuffer(0),
+            response: {
+              userHandle: new TextEncoder().encode('atone1test123').buffer,
+            } as any,
+            type: 'public-key' as const,
+            authenticatorAttachment: null,
+            getClientExtensionResults: () => ({
+              prf: {
+                results: {
+                  first: new Uint8Array(32).fill(123),
+                },
+              },
+            }),
+          } as any
+        })
+
+        // Test with different window sizes at the same timestamp
+        const timestamp = Date.now()
+        const originalDateNow = Date.now
+        Date.now = vi.fn().mockReturnValue(timestamp)
+        
+        try {
+          // 24 hour window
+          await getOrCreateDerivedKey({
+            address: 'atone1test123',
+            saltName: 'test-salt',
+            stintWindowHours: 24,
+          })
+
+          // 8 hour window  
+          await getOrCreateDerivedKey({
+            address: 'atone1test123',
+            saltName: 'test-salt',
+            stintWindowHours: 8,
+          })
+
+          // Should have different window numbers due to different window sizes
+          expect(capturedSalts).toHaveLength(2)
+          expect(capturedSalts[0]).not.toBe(capturedSalts[1])
+          
+          // Extract window numbers
+          const windowNumber24h = parseInt(capturedSalts[0].split(':')[3])
+          const windowNumber8h = parseInt(capturedSalts[1].split(':')[3])
+          expect(windowNumber24h).not.toBe(windowNumber8h)
+          
+        } finally {
+          Date.now = originalDateNow
+        }
+      })
     })
   })
 })

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -1,4 +1,3 @@
-import { sha256 } from '@cosmjs/crypto'
 import { toHex, fromBase64 } from '@cosmjs/encoding'
 import { PublicKeyCredentialWithPRF } from './types'
 import { StintError, ErrorCodes } from './errors'
@@ -7,6 +6,43 @@ import { Logger, noopLogger } from './logger'
 // ============================================================================
 // SECURITY UTILITIES
 // ============================================================================
+
+/**
+ * Generate time-windowed stint salt for PRF and HKDF
+ * Creates unique salt based on domain, user, purpose, and UTC time window
+ * Uses Unix epoch-based calculation to handle arbitrary window sizes
+ */
+function generateStintSalt(
+  userAddress: string,
+  purpose: string,
+  windowHours: number = 24,
+  windowNumber?: number
+): string {
+  // Use UTC milliseconds since Unix epoch for global synchronization
+  const now = Date.now()
+  const windowMs = windowHours * 60 * 60 * 1000
+  const calculatedWindowNumber = windowNumber ?? Math.floor(now / windowMs)
+  
+  const domain = window.location.hostname
+  return `${domain}:${userAddress}:${purpose}:${calculatedWindowNumber}`
+}
+
+/**
+ * Get the current window boundaries for debugging and validation
+ * @param windowHours The window size in hours
+ * @returns Object with start and end timestamps of current window
+ */
+export function getWindowBoundaries(windowHours: number = 24): { start: Date; end: Date; windowNumber: number } {
+  const now = Date.now()
+  const windowMs = windowHours * 60 * 60 * 1000
+  const windowNumber = Math.floor(now / windowMs)
+  
+  return {
+    start: new Date(windowNumber * windowMs),
+    end: new Date((windowNumber + 1) * windowMs),
+    windowNumber,
+  }
+}
 
 /**
  * Validate and get secure RP ID
@@ -48,6 +84,45 @@ function generateSecureChallenge(): Uint8Array {
   return challenge
 }
 
+
+
+/**
+ * HKDF-SHA256 key derivation function using WebCrypto API
+ * @param ikm Input Key Material (PRF output)
+ * @param salt Salt for extraction phase
+ * @param info Context information for expansion
+ * @param length Output length in bytes
+ */
+async function hkdf(
+  ikm: Uint8Array,
+  salt: Uint8Array,
+  info: Uint8Array,
+  length: number
+): Promise<Uint8Array> {
+  // Import the input key material
+  const key = await crypto.subtle.importKey(
+    'raw',
+    ikm,
+    'HKDF',
+    false,
+    ['deriveBits']
+  )
+
+  // Derive bits using HKDF-SHA256
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt: salt,
+      info: info,
+    },
+    key,
+    length * 8 // Convert bytes to bits
+  )
+
+  return new Uint8Array(derivedBits)
+}
+
 // Public interfaces
 export interface DerivedKey {
   credentialId: string
@@ -58,6 +133,8 @@ export interface PasskeyConfig {
   address: string // Cosmos address as userID
   displayName?: string // Optional display name
   saltName?: string // Salt for key derivation (default: 'stint-session')
+  stintWindowHours?: number // Time window in hours for key validity (default: 24, supports any duration)
+  windowNumber?: number // Specific window number to use (optional, for grace period logic)
   logger?: Logger // Optional logger
 }
 
@@ -69,10 +146,17 @@ export interface PasskeyConfig {
  */
 export async function getOrCreateDerivedKey(options: PasskeyConfig): Promise<DerivedKey> {
   const logger = options.logger || noopLogger
+  const purpose = options.saltName || 'stint-session'
+  const windowHours = options.stintWindowHours || 24
+
+  // Generate time-windowed stint salt
+  const stintSalt = generateStintSalt(options.address, purpose, windowHours, options.windowNumber)
 
   logger.debug('Starting passkey derivation', {
     address: options.address.slice(0, 10) + '...',
-    saltName: options.saltName,
+    purpose,
+    windowHours,
+    stintSalt,
   })
 
   if (!window.PublicKeyCredential) {
@@ -88,7 +172,7 @@ export async function getOrCreateDerivedKey(options: PasskeyConfig): Promise<Der
   try {
     existingCredential = await getExistingPasskey(
       options.address,
-      options.saltName || 'stint-session',
+      stintSalt,
       logger
     )
   } catch (error) {
@@ -107,15 +191,13 @@ export async function getOrCreateDerivedKey(options: PasskeyConfig): Promise<Der
     logger.debug('No existing passkey found, will create new one')
   }
 
-  const saltName = options.saltName || 'stint-session'
-
   // If we found an existing credential, try to use it
   if (existingCredential) {
     logger.debug('Found existing passkey')
 
     if (existingCredential.prfSupported && existingCredential.prfOutput) {
-      // Use the PRF output we already got to derive the private key
-      const privateKey = sha256(existingCredential.prfOutput)
+      // Use the PRF output we already got to derive the private key with HKDF
+      const privateKey = await derivePrivateKeyWithHKDF(existingCredential.prfOutput, stintSalt, logger)
       logger.debug('Session key ready')
       return {
         credentialId: existingCredential.credentialId,
@@ -123,7 +205,7 @@ export async function getOrCreateDerivedKey(options: PasskeyConfig): Promise<Der
       }
     } else if (existingCredential.prfSupported) {
       try {
-        const privateKey = await derivePrivateKey(existingCredential.credentialId, saltName, logger)
+        const privateKey = await derivePrivateKey(existingCredential.credentialId, stintSalt, logger)
         logger.debug('Session key ready')
         return {
           credentialId: existingCredential.credentialId,
@@ -168,7 +250,7 @@ export async function getOrCreateDerivedKey(options: PasskeyConfig): Promise<Der
     logger
   )
 
-  const privateKey = await derivePrivateKey(credential.id, saltName, logger)
+  const privateKey = await derivePrivateKey(credential.id, stintSalt, logger)
 
   logger.debug('Session key ready')
   return {
@@ -192,11 +274,10 @@ interface ExistingCredential {
 // Check for existing passkey with PRF support
 async function getExistingPasskey(
   address: string,
-  saltName: string = 'stint-session',
+  stintSalt: string,
   logger: Logger = noopLogger
 ): Promise<ExistingCredential | null> {
   const challenge = generateSecureChallenge()
-  const saltBytes = new TextEncoder().encode(saltName)
 
   try {
     const publicKeyCredentialRequestOptions: PublicKeyCredentialRequestOptions = {
@@ -208,7 +289,8 @@ async function getExistingPasskey(
       extensions: {
         prf: {
           eval: {
-            first: saltBytes,
+            first: new TextEncoder().encode(stintSalt + '\x00'),
+            second: new TextEncoder().encode(stintSalt + '\x01'),
           },
         },
       },
@@ -241,20 +323,42 @@ async function getExistingPasskey(
 
     // Check if PRF extension is supported and extract output
     const clientExtensionResults = assertion.getClientExtensionResults()
-    const prfResult = clientExtensionResults.prf?.results?.first
-    const prfSupported = !!prfResult
+    const prfResult1 = clientExtensionResults.prf?.results?.first
+    const prfResult2 = clientExtensionResults.prf?.results?.second
+    const prfSupported = !!prfResult1
 
     let prfOutput: Uint8Array | undefined
-    if (prfResult) {
-      // Handle different possible return types from PRF
-      if (prfResult instanceof ArrayBuffer) {
-        prfOutput = new Uint8Array(prfResult)
-      } else if (prfResult instanceof Uint8Array) {
-        prfOutput = prfResult
+    if (prfResult1) {
+      // Convert first result to Uint8Array
+      let output1: Uint8Array
+      if (prfResult1 instanceof ArrayBuffer) {
+        output1 = new Uint8Array(prfResult1)
+      } else if (prfResult1 instanceof Uint8Array) {
+        output1 = prfResult1
       } else {
-        // Handle BufferSource types
-        prfOutput = new Uint8Array(prfResult as ArrayBuffer)
+        output1 = new Uint8Array(prfResult1 as ArrayBuffer)
       }
+
+      // Convert second result to Uint8Array (if available)
+      let output2: Uint8Array
+      if (prfResult2) {
+        if (prfResult2 instanceof ArrayBuffer) {
+          output2 = new Uint8Array(prfResult2)
+        } else if (prfResult2 instanceof Uint8Array) {
+          output2 = prfResult2
+        } else {
+          output2 = new Uint8Array(prfResult2 as ArrayBuffer)
+        }
+      } else {
+        // If second output is not available, use first output again
+        output2 = output1
+      }
+
+      // Combine both outputs for maximum entropy
+      const combinedOutput = new Uint8Array(output1.length + output2.length)
+      combinedOutput.set(output1)
+      combinedOutput.set(output2, output1.length)
+      prfOutput = combinedOutput
     }
 
     return {
@@ -368,7 +472,7 @@ function base64urlToBytes(base64url: string): Uint8Array {
 // Get PRF output from passkey
 async function getPasskeyPRF(
   credentialId: string,
-  salt: Uint8Array,
+  stintSalt: string,
   logger: Logger = noopLogger
 ): Promise<Uint8Array> {
   const challenge = generateSecureChallenge()
@@ -388,7 +492,8 @@ async function getPasskeyPRF(
     extensions: {
       prf: {
         eval: {
-          first: salt,
+          first: new TextEncoder().encode(stintSalt + '\x00'),
+          second: new TextEncoder().encode(stintSalt + '\x01'),
         },
       },
     },
@@ -416,30 +521,68 @@ async function getPasskeyPRF(
     })
   }
 
-  // Handle different possible return types from PRF
-  const prfResult = clientExtensionResults.prf.results.first
-  if (prfResult instanceof ArrayBuffer) {
-    return new Uint8Array(prfResult)
-  } else if (prfResult instanceof Uint8Array) {
-    return prfResult
+  // Handle different possible return types from PRF and combine both outputs
+  const prfResult1 = clientExtensionResults.prf.results.first
+  const prfResult2 = clientExtensionResults.prf.results.second
+
+  // Convert first result to Uint8Array
+  let output1: Uint8Array
+  if (prfResult1 instanceof ArrayBuffer) {
+    output1 = new Uint8Array(prfResult1)
+  } else if (prfResult1 instanceof Uint8Array) {
+    output1 = prfResult1
   } else {
-    // Handle BufferSource types
-    return new Uint8Array(prfResult as ArrayBuffer)
+    output1 = new Uint8Array(prfResult1 as ArrayBuffer)
   }
+
+  // Convert second result to Uint8Array (if available)
+  let output2: Uint8Array
+  if (prfResult2) {
+    if (prfResult2 instanceof ArrayBuffer) {
+      output2 = new Uint8Array(prfResult2)
+    } else if (prfResult2 instanceof Uint8Array) {
+      output2 = prfResult2
+    } else {
+      output2 = new Uint8Array(prfResult2 as ArrayBuffer)
+    }
+  } else {
+    // If second output is not available, use first output again
+    output2 = output1
+  }
+
+  // Combine both outputs for maximum entropy
+  const combinedOutput = new Uint8Array(output1.length + output2.length)
+  combinedOutput.set(output1)
+  combinedOutput.set(output2, output1.length)
+
+  return combinedOutput
+}
+
+// Derive a private key using HKDF from PRF output
+async function derivePrivateKeyWithHKDF(
+  prfOutput: Uint8Array,
+  stintSalt: string,
+  _logger: Logger = noopLogger
+): Promise<Uint8Array> {
+  const saltBytes = new TextEncoder().encode(stintSalt)
+  const infoBytes = new TextEncoder().encode('stint-key-derivation')
+
+  // Use HKDF to derive the private key
+  const privateKey = await hkdf(prfOutput, saltBytes, infoBytes, 32)
+
+  return privateKey
 }
 
 // Derive a private key from passkey PRF output
 async function derivePrivateKey(
   credentialId: string,
-  salt: string = 'stint-session',
+  stintSalt: string,
   logger: Logger = noopLogger
 ): Promise<string> {
-  const saltBytes = new TextEncoder().encode(salt)
+  const prfOutput = await getPasskeyPRF(credentialId, stintSalt, logger)
 
-  const prfOutput = await getPasskeyPRF(credentialId, saltBytes, logger)
-
-  // Use the PRF output as entropy for the private key
-  const privateKey = sha256(prfOutput)
+  // Use HKDF to derive the private key
+  const privateKey = await derivePrivateKeyWithHKDF(prfOutput, stintSalt, logger)
 
   return toHex(privateKey)
 }

--- a/src/passkey.ts
+++ b/src/passkey.ts
@@ -22,7 +22,7 @@ function generateStintSalt(
   const now = Date.now()
   const windowMs = windowHours * 60 * 60 * 1000
   const calculatedWindowNumber = windowNumber ?? Math.floor(now / windowMs)
-  
+
   const domain = window.location.hostname
   return `${domain}:${userAddress}:${purpose}:${calculatedWindowNumber}`
 }
@@ -32,11 +32,15 @@ function generateStintSalt(
  * @param windowHours The window size in hours
  * @returns Object with start and end timestamps of current window
  */
-export function getWindowBoundaries(windowHours: number = 24): { start: Date; end: Date; windowNumber: number } {
+export function getWindowBoundaries(windowHours: number = 24): {
+  start: Date
+  end: Date
+  windowNumber: number
+} {
   const now = Date.now()
   const windowMs = windowHours * 60 * 60 * 1000
   const windowNumber = Math.floor(now / windowMs)
-  
+
   return {
     start: new Date(windowNumber * windowMs),
     end: new Date((windowNumber + 1) * windowMs),
@@ -84,8 +88,6 @@ function generateSecureChallenge(): Uint8Array {
   return challenge
 }
 
-
-
 /**
  * HKDF-SHA256 key derivation function using WebCrypto API
  * @param ikm Input Key Material (PRF output)
@@ -100,13 +102,7 @@ async function hkdf(
   length: number
 ): Promise<Uint8Array> {
   // Import the input key material
-  const key = await crypto.subtle.importKey(
-    'raw',
-    ikm,
-    'HKDF',
-    false,
-    ['deriveBits']
-  )
+  const key = await crypto.subtle.importKey('raw', ikm, 'HKDF', false, ['deriveBits'])
 
   // Derive bits using HKDF-SHA256
   const derivedBits = await crypto.subtle.deriveBits(
@@ -170,11 +166,7 @@ export async function getOrCreateDerivedKey(options: PasskeyConfig): Promise<Der
   let existingCredential: ExistingCredential | null = null
 
   try {
-    existingCredential = await getExistingPasskey(
-      options.address,
-      stintSalt,
-      logger
-    )
+    existingCredential = await getExistingPasskey(options.address, stintSalt, logger)
   } catch (error) {
     // If user cancelled during existing passkey check, don't proceed to create
     if (
@@ -197,7 +189,11 @@ export async function getOrCreateDerivedKey(options: PasskeyConfig): Promise<Der
 
     if (existingCredential.prfSupported && existingCredential.prfOutput) {
       // Use the PRF output we already got to derive the private key with HKDF
-      const privateKey = await derivePrivateKeyWithHKDF(existingCredential.prfOutput, stintSalt, logger)
+      const privateKey = await derivePrivateKeyWithHKDF(
+        existingCredential.prfOutput,
+        stintSalt,
+        logger
+      )
       logger.debug('Session key ready')
       return {
         credentialId: existingCredential.credentialId,
@@ -205,7 +201,11 @@ export async function getOrCreateDerivedKey(options: PasskeyConfig): Promise<Der
       }
     } else if (existingCredential.prfSupported) {
       try {
-        const privateKey = await derivePrivateKey(existingCredential.credentialId, stintSalt, logger)
+        const privateKey = await derivePrivateKey(
+          existingCredential.credentialId,
+          stintSalt,
+          logger
+        )
         logger.debug('Session key ready')
         return {
           credentialId: existingCredential.credentialId,

--- a/src/stint.test.ts
+++ b/src/stint.test.ts
@@ -760,7 +760,7 @@ describe('SessionSigner methods', () => {
 
     beforeEach(async () => {
       originalDateNow = Date.now
-      
+
       // Create mock primary client
       mockPrimaryClient = {
         signer: {
@@ -871,61 +871,65 @@ describe('SessionSigner methods', () => {
         },
       ]
 
-      windowSelectionTestCases.forEach(({ 
-        name, 
-        timestamp, 
-        windowHours, 
-        usePreviousWindow, 
-        expectedWindowNumber, 
-        description 
-      }) => {
-        it(`should handle ${name}`, async () => {
-          // Mock Date.now to return our test timestamp
-          Date.now = vi.fn().mockReturnValue(timestamp)
+      windowSelectionTestCases.forEach(
+        ({
+          name,
+          timestamp,
+          windowHours,
+          usePreviousWindow,
+          expectedWindowNumber,
+          description,
+        }) => {
+          it(`should handle ${name}`, async () => {
+            // Mock Date.now to return our test timestamp
+            Date.now = vi.fn().mockReturnValue(timestamp)
 
-          // Track which window number is actually used in the passkey derivation
-          let actualWindowNumber: number | undefined
-          
-          // Mock getOrCreateDerivedKey to capture the window number
-          const mockGetOrCreateDerivedKey = vi.mocked(await import('./passkey')).getOrCreateDerivedKey
-          mockGetOrCreateDerivedKey.mockImplementation(async (config) => {
-            actualWindowNumber = config.windowNumber
-            return {
-              credentialId: 'mock-credential-id',
-              privateKey: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-            }
-          })
+            // Track which window number is actually used in the passkey derivation
+            let actualWindowNumber: number | undefined
 
-          // Create session signer with the specified configuration
-          await newSessionSigner({
-            primaryClient: mockPrimaryClient,
-            saltName: 'test-salt',
-            stintWindowHours: windowHours,
-            usePreviousWindow: usePreviousWindow,
-          })
-
-          // Verify the correct window number was passed to passkey derivation
-          expect(actualWindowNumber).toBe(expectedWindowNumber)
-          
-          // Verify getOrCreateDerivedKey was called with the expected config
-          expect(mockGetOrCreateDerivedKey).toHaveBeenCalledWith(
-            expect.objectContaining({
-              stintWindowHours: windowHours,
-              windowNumber: expectedWindowNumber,
+            // Mock getOrCreateDerivedKey to capture the window number
+            const mockGetOrCreateDerivedKey = vi.mocked(
+              await import('./passkey')
+            ).getOrCreateDerivedKey
+            mockGetOrCreateDerivedKey.mockImplementation(async (config) => {
+              actualWindowNumber = config.windowNumber
+              return {
+                credentialId: 'mock-credential-id',
+                privateKey: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              }
             })
-          )
-          
-          // Log description for documentation
-          expect(description).toBeDefined()
-        })
-      })
+
+            // Create session signer with the specified configuration
+            await newSessionSigner({
+              primaryClient: mockPrimaryClient,
+              saltName: 'test-salt',
+              stintWindowHours: windowHours,
+              usePreviousWindow: usePreviousWindow,
+            })
+
+            // Verify the correct window number was passed to passkey derivation
+            expect(actualWindowNumber).toBe(expectedWindowNumber)
+
+            // Verify getOrCreateDerivedKey was called with the expected config
+            expect(mockGetOrCreateDerivedKey).toHaveBeenCalledWith(
+              expect.objectContaining({
+                stintWindowHours: windowHours,
+                windowNumber: expectedWindowNumber,
+              })
+            )
+
+            // Log description for documentation
+            expect(description).toBeDefined()
+          })
+        }
+      )
 
       it('should default to current window when usePreviousWindow not specified', async () => {
         const timestamp = 72 * 60 * 60 * 1000 // 72 hours = 3 full 24h windows
         Date.now = vi.fn().mockReturnValue(timestamp)
 
         let actualWindowNumber: number | undefined
-        
+
         const mockGetOrCreateDerivedKey = vi.mocked(await import('./passkey')).getOrCreateDerivedKey
         mockGetOrCreateDerivedKey.mockImplementation(async (config) => {
           actualWindowNumber = config.windowNumber
@@ -953,7 +957,7 @@ describe('SessionSigner methods', () => {
         Date.now = vi.fn().mockReturnValue(timestamp)
 
         let actualWindowNumber: number | undefined
-        
+
         const mockGetOrCreateDerivedKey = vi.mocked(await import('./passkey')).getOrCreateDerivedKey
         mockGetOrCreateDerivedKey.mockImplementation(async (config) => {
           actualWindowNumber = config.windowNumber
@@ -1016,29 +1020,33 @@ describe('SessionSigner methods', () => {
         },
       ]
 
-      windowHoursTestCases.forEach(({ name, stintWindowHours, expectedWindowHours, description }) => {
-        it(`should handle ${name}`, async () => {
-          let actualStintWindowHours: number | undefined
-          
-          const mockGetOrCreateDerivedKey = vi.mocked(await import('./passkey')).getOrCreateDerivedKey
-          mockGetOrCreateDerivedKey.mockImplementation(async (config) => {
-            actualStintWindowHours = config.stintWindowHours
-            return {
-              credentialId: 'mock-credential-id',
-              privateKey: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-            }
-          })
+      windowHoursTestCases.forEach(
+        ({ name, stintWindowHours, expectedWindowHours, description }) => {
+          it(`should handle ${name}`, async () => {
+            let actualStintWindowHours: number | undefined
 
-          await newSessionSigner({
-            primaryClient: mockPrimaryClient,
-            saltName: 'test-salt',
-            stintWindowHours: stintWindowHours,
-          })
+            const mockGetOrCreateDerivedKey = vi.mocked(
+              await import('./passkey')
+            ).getOrCreateDerivedKey
+            mockGetOrCreateDerivedKey.mockImplementation(async (config) => {
+              actualStintWindowHours = config.stintWindowHours
+              return {
+                credentialId: 'mock-credential-id',
+                privateKey: '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+              }
+            })
 
-          expect(actualStintWindowHours).toBe(expectedWindowHours)
-          expect(description).toBeDefined()
-        })
-      })
+            await newSessionSigner({
+              primaryClient: mockPrimaryClient,
+              saltName: 'test-salt',
+              stintWindowHours: stintWindowHours,
+            })
+
+            expect(actualStintWindowHours).toBe(expectedWindowHours)
+            expect(description).toBeDefined()
+          })
+        }
+      )
     })
 
     describe('window calculation consistency', () => {
@@ -1047,7 +1055,7 @@ describe('SessionSigner methods', () => {
         Date.now = vi.fn().mockReturnValue(timestamp)
 
         const capturedConfigs: any[] = []
-        
+
         const mockGetOrCreateDerivedKey = vi.mocked(await import('./passkey')).getOrCreateDerivedKey
         mockGetOrCreateDerivedKey.mockImplementation(async (config) => {
           capturedConfigs.push(config)
@@ -1081,7 +1089,7 @@ describe('SessionSigner methods', () => {
         Date.now = vi.fn().mockReturnValue(timestamp)
 
         const capturedConfigs: any[] = []
-        
+
         const mockGetOrCreateDerivedKey = vi.mocked(await import('./passkey')).getOrCreateDerivedKey
         mockGetOrCreateDerivedKey.mockImplementation(async (config) => {
           capturedConfigs.push(config)

--- a/src/stint.ts
+++ b/src/stint.ts
@@ -23,7 +23,6 @@ import { createExecuteHelpers } from './execute'
 // SESSION SIGNER CREATION
 // ============================================================================
 
-
 /**
  * Create a complete session signer in one step
  * Combines passkey creation, signer derivation, and chain connection

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,8 @@ export interface StintConfig {
 export interface SessionSignerConfig {
   primaryClient: SigningStargateClient
   saltName?: string
+  stintWindowHours?: number // Time window in hours for key validity (default: 24, supports any duration)
+  usePreviousWindow?: boolean // Use previous window instead of current (default: false)
   logger?: Logger
 }
 


### PR DESCRIPTION
This introduces signers that have improved security features as introduced by a Filippo article.

 https://words.filippo.io/passkey-encryption/

This updates our salt algorithm to give a more specific PRF namespace that includes the domain, the address, the purpose and a validity window. This gives us some nice security features, including automated stint key rotation. 